### PR TITLE
Apply mob effects only when the target is hit

### DIFF
--- a/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityIceBall.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityIceBall.java
@@ -52,11 +52,10 @@ public class EntityIceBall extends EntityMagicEffect implements IProjectile {
         if (!entitiesHit.isEmpty()) {
             for (Entity entity : entitiesHit) {
                 if (entity == caster) continue;
-                if (entity.getIsInvulnerable()) continue;
-                if (entity instanceof EntityPlayer && ((EntityPlayer) entity).capabilities.isCreativeMode) continue;
-                entity.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), 3f * ConfigHandler.FROSTMAW.combatData.attackMultiplier);
-                MowzieLivingProperties property = EntityPropertiesHandler.INSTANCE.getProperties(entity, MowzieLivingProperties.class);
-                if (property != null) property.freezeProgress += 1;
+                if (entity.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), 3f * ConfigHandler.FROSTMAW.combatData.attackMultiplier)) {
+                    MowzieLivingProperties property = EntityPropertiesHandler.INSTANCE.getProperties(entity, MowzieLivingProperties.class);
+                    if (property != null) property.freezeProgress += 1;
+                }
             }
         }
 

--- a/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityIceBreath.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityIceBreath.java
@@ -127,9 +127,10 @@ public class EntityIceBreath extends EntityMagicEffect {
             boolean yawCheck = (entityRelativeYaw <= ARC / 2f && entityRelativeYaw >= -ARC / 2f) || (entityRelativeYaw >= 360 - ARC / 2f || entityRelativeYaw <= -360 + ARC / 2f);
             boolean pitchCheck = (entityRelativePitch <= ARC / 2f && entityRelativePitch >= -ARC / 2f) || (entityRelativePitch >= 360 - ARC / 2f || entityRelativePitch <= -360 + ARC / 2f);
             if (inRange && yawCheck && pitchCheck) {
-                entityHit.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), damage);
-                MowzieLivingProperties property = EntityPropertiesHandler.INSTANCE.getProperties(entityHit, MowzieLivingProperties.class);
-                if (property != null) property.freezeProgress += 0.13;
+                if (entityHit.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), damage)) {
+                    MowzieLivingProperties property = EntityPropertiesHandler.INSTANCE.getProperties(entityHit, MowzieLivingProperties.class);
+                    if (property != null) property.freezeProgress += 0.13;
+                }
             }
         }
     }

--- a/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityPoisonBall.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityPoisonBall.java
@@ -64,11 +64,10 @@ public class EntityPoisonBall extends EntityMagicEffect implements IProjectile {
         if (!entitiesHit.isEmpty()) {
             for (EntityLivingBase entity : entitiesHit) {
                 if (entity == caster) continue;
-                if (entity.getIsInvulnerable()) continue;
-                if (entity instanceof EntityPlayer && ((EntityPlayer) entity).capabilities.isCreativeMode) continue;
                 if (entity instanceof EntityNaga) continue;
-                entity.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), 3 * ConfigHandler.NAGA.combatData.attackMultiplier);
-                entity.addPotionEffect(new PotionEffect(MobEffects.POISON, 80, 1, false, true));
+                if (entity.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), 3 * ConfigHandler.NAGA.combatData.attackMultiplier)) {
+                    entity.addPotionEffect(new PotionEffect(MobEffects.POISON, 80, 1, false, true));
+                }
             }
         }
 
@@ -147,11 +146,10 @@ public class EntityPoisonBall extends EntityMagicEffect implements IProjectile {
         if (!entitiesHit.isEmpty()) {
             for (EntityLivingBase entity : entitiesHit) {
                 if (entity == caster) continue;
-                if (entity.getIsInvulnerable()) continue;
-                if (entity instanceof EntityPlayer && ((EntityPlayer) entity).capabilities.isCreativeMode) continue;
                 if (entity instanceof EntityNaga) continue;
-                entity.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), 3 * ConfigHandler.NAGA.combatData.attackMultiplier);
-                entity.addPotionEffect(new PotionEffect(MobEffects.POISON, 80, 0, false, true));
+                if (entity.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), 3 * ConfigHandler.NAGA.combatData.attackMultiplier)) {
+                    entity.addPotionEffect(new PotionEffect(MobEffects.POISON, 80, 0, false, true));
+                }
             }
         }
 

--- a/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntitySunstrike.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntitySunstrike.java
@@ -206,8 +206,9 @@ public class EntitySunstrike extends Entity implements IEntityAdditionalSpawnDat
                     damageMob *= ConfigHandler.TOOLS_AND_ABILITIES.sunsBlessingAttackMultiplier;
                 }
                 if (entity.attackEntityFrom(DamageSource.causeMobDamage(caster), damageMob)) entity.hurtResistantTime = 0;
-                entity.attackEntityFrom(DamageSource.ON_FIRE, damageFire);
-                entity.setFire(5);
+                if (entity.attackEntityFrom(DamageSource.ON_FIRE, damageFire)) {
+                    entity.setFire(5);
+                }
             }
         }
     }

--- a/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntitySuperNova.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntitySuperNova.java
@@ -85,8 +85,10 @@ public class EntitySuperNova extends EntityMagicEffect {
                         entity.knockBack(this, 0.4f, -diff.x, -diff.z);
                     }
                     entity.attackEntityFrom(DamageSource.causeMobDamage(caster), damageMob);
-                    if (hitWithFire) entity.hurtResistantTime = entity.maxHurtResistantTime;
-                    entity.setFire(5);
+                    if (hitWithFire) {
+                        entity.hurtResistantTime = entity.maxHurtResistantTime;
+                        entity.setFire(5);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This check makes it so that if some mods cancel the attack event the effect (such as poison, fire or the custom freeze effect) does not get applied. The attackEntityFrom() method also checks for creative/invulnerable so I removed those checks.