### PR TITLE
Fixes the issue where the entities will not get frozen.

### DIFF
--- a/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityIceBreath.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/entity/effects/EntityIceBreath.java
@@ -18,6 +18,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeHooks;
 
 import java.util.List;
 
@@ -127,9 +128,14 @@ public class EntityIceBreath extends EntityMagicEffect {
             boolean yawCheck = (entityRelativeYaw <= ARC / 2f && entityRelativeYaw >= -ARC / 2f) || (entityRelativeYaw >= 360 - ARC / 2f || entityRelativeYaw <= -360 + ARC / 2f);
             boolean pitchCheck = (entityRelativePitch <= ARC / 2f && entityRelativePitch >= -ARC / 2f) || (entityRelativePitch >= 360 - ARC / 2f || entityRelativePitch <= -360 + ARC / 2f);
             if (inRange && yawCheck && pitchCheck) {
-                if (entityHit.attackEntityFrom(DamageSource.causeIndirectMagicDamage(this, caster), damage)) {
+                DamageSource damageSource = DamageSource.causeIndirectMagicDamage(this, caster);
+                boolean shouldBeHit = ForgeHooks.onLivingAttack(entityHit, damageSource, damage);
+                if (shouldBeHit) {
                     MowzieLivingProperties property = EntityPropertiesHandler.INSTANCE.getProperties(entityHit, MowzieLivingProperties.class);
-                    if (property != null) property.freezeProgress += 0.13;
+                    entityHit.attackEntityFrom(damageSource, damage);
+                    if (property != null) {
+                        property.freezeProgress += 0.13;
+                    }
                 }
             }
         }


### PR DESCRIPTION
I found an issue with #251 where the ice breath will not freeze entities. This was because the freeze progress is applied every tick, but the `attackEntityFrom()` method returns true only when the hurt cooldown is off, which is not every tick, meaning that the freeze progress would wear off before another `+= 0.13` is applied.

This fixes this issue, though admittedly in not so elegant manner. It calls the onLivingAttack event before any damage should be applied and if so it then causes the damage and the progress to increase. This means that for this one attack the same event is triggered twice which I guess has a chance to trigger undesirable effect with other mods.

I can't think of any other ways to make it so that this attack can be cancelled from other mods, other that tweaking how the freeze progress works, which I don't expect that you to do.

If you do not like the way I have handled the work around then let me know and I will make a new PR which reverts the way that the ice breath works to how it used to be before #251.

Note: This issue only affects the ice breath because its the only one that work continuously rather than applying effects once, so the other ones still appear to function as intended.