### PR TITLE
Remove extra brackets

### DIFF
--- a/src/main/resources/data/mowziesmobs/advancements/kill_grottol_silk_touch.json
+++ b/src/main/resources/data/mowziesmobs/advancements/kill_grottol_silk_touch.json
@@ -15,7 +15,6 @@
   "criteria": {
     "steal_crystal": {
       "trigger": "mowziesmobs:kill_grottol_silk_touch"
-      }
     }
   }
 }

--- a/src/main/resources/data/mowziesmobs/advancements/steal_ice_crystal.json
+++ b/src/main/resources/data/mowziesmobs/advancements/steal_ice_crystal.json
@@ -15,7 +15,6 @@
   "criteria": {
     "steal_crystal": {
       "trigger": "mowziesmobs:steal_ice_crystal"
-      }
     }
   }
 }


### PR DESCRIPTION
I first noticed these in 1.12, but I'm not sure if lower versions are supported anymore, so here's the same fix for 1.15.