### PR TITLE
(1.16.5) Optimise AvoidEntityIfNotTamedGoal

### DIFF
--- a/src/main/java/com/bobmowzie/mowziesmobs/server/ai/AvoidEntityIfNotTamedGoal.java
+++ b/src/main/java/com/bobmowzie/mowziesmobs/server/ai/AvoidEntityIfNotTamedGoal.java
@@ -12,8 +12,6 @@ public class AvoidEntityIfNotTamedGoal<T extends LivingEntity> extends AvoidEnti
 
     @Override
     public boolean shouldExecute() {
-        boolean isTamed;
-        isTamed = entity instanceof TameableEntity && ((TameableEntity) entity).isTamed();
-        return super.shouldExecute() && !isTamed;
+        return super.shouldExecute() && !(entity instanceof TameableEntity && ((TameableEntity) entity).isTamed());
     }
 }


### PR DESCRIPTION
Before, both `isTamed` and `super.shouldExecute()` were always checked.

Now, the isTamed check is skipped as intended if super.shouldExecute() is true.